### PR TITLE
Use dark theme for code snippet style

### DIFF
--- a/src/components/example.css
+++ b/src/components/example.css
@@ -1,8 +1,10 @@
 .code-block {
   max-width: 30em;
   border: 1px solid rgb(94, 94, 94);
+  border-radius: 10px;
+  padding: 7px;
   display: flex;
-  background: #f0f0f0;
+  background: #444444;
 }
 
 .code-block-inner {

--- a/src/components/renderer.js
+++ b/src/components/renderer.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import SyntaxHighlighter from "react-syntax-highlighter";
+import { dark } from 'react-syntax-highlighter/styles/hljs'
 
 export default class CodeBlock extends React.PureComponent {
   static propTypes = {
@@ -15,6 +16,13 @@ export default class CodeBlock extends React.PureComponent {
   render() {
     const { language, value } = this.props;
 
-    return <SyntaxHighlighter language={language}>{value}</SyntaxHighlighter>;
+    return (
+        <SyntaxHighlighter
+          language={language}
+          style={dark}
+        >
+          {value}
+        </SyntaxHighlighter>
+    );
   }
 }


### PR DESCRIPTION
I see that there is another PR with tooltip, therefore I have not added in here. 
So if you would combine these 2 PRs. If you see that you like, I could try improving the style further.
Here is how it looks now:
![image](https://user-images.githubusercontent.com/3036090/47113848-c9426600-d262-11e8-81f3-cb2b0e4f32ba.png)

